### PR TITLE
Package database formatting changes, man page and typos

### DIFF
--- a/docs/spkg.8
+++ b/docs/spkg.8
@@ -86,6 +86,16 @@ Disable postinstallation script.
 .TP
 \fB--no-ldconfig\fR
 Don't execute ldconfig after installation and upgrade.
+.TP
+\fB--no-gtk-update-icon-cache\fR
+When a package includes a .desktop file, in other words when a package
+includes a menu entry, spkg by default runs gtk-update-icon-cache, so
+that the icon cache will be updated, ensuring that the menu icon will
+be displayed properly at all times. Using this option, this behaviour
+is disabled. Useful if you want to install a large number of packages
+that include menu entries; installation will be faster without updating
+the icon cache after installing every package. The user could run
+gtk-update-icon-cache manually after all packages have been installed.
 .CM ===========================================================================
 .SS Help
 .TP

--- a/src/cmd-install.c
+++ b/src/cmd-install.c
@@ -460,7 +460,7 @@ static void _extract_file(struct untgz_state* tgz, struct db_pkg* pkg,
         }
         else if (tmp_type == SYS_DIR)
         {
-          e_set(E_ERROR, "Temporary file path is used by a direcotry. (%s)", temppath);
+          e_set(E_ERROR, "Temporary file path is used by a directory. (%s)", temppath);
           goto extract_failed;
         }
         else if (tmp_type != SYS_NONE)

--- a/src/cmd-install.c
+++ b/src/cmd-install.c
@@ -1,4 +1,4 @@
-/*----------------------------------------------------------------------*\
+/*----------------------------------------------------------------------*
 |* spkg - The Unofficial Slackware Linux Package Manager                *|
 |*                                      designed by Ondøej Jirman, 2005 *|
 |*----------------------------------------------------------------------*|
@@ -652,6 +652,7 @@ gint cmd_install(const gchar* pkgfile, const struct cmd_options* opts, struct er
         goto err3;
       }
       _read_slackdesc(tgz, pkg);
+      db_pkg_add_path(pkg, "install/slack-desc", DB_PATH_FILE);
       continue;
     }
     else if (!strcmp(sane_path, "install/doinst.sh"))
@@ -667,6 +668,7 @@ gint cmd_install(const gchar* pkgfile, const struct cmd_options* opts, struct er
         e_set(E_ERROR, "Installation script processing failed.");
         goto err3;
       }
+      db_pkg_add_path(pkg, "install/doinst.sh", DB_PATH_FILE);
       continue;
     }
     else if (!strncmp(sane_path, "install/", 8) && strcmp(sane_path, "install"))

--- a/src/cmd-install.c
+++ b/src/cmd-install.c
@@ -306,12 +306,12 @@ static void _extract_file(struct untgz_state* tgz, struct db_pkg* pkg,
         }
         else
         {
-          _debug("Direcory already exists %s", sane_path);
+          _debug("Directory already exists %s", sane_path);
         }
       }
       else if (ex_type == SYS_SYM && ex_deref_type == SYS_DIR)
       {
-        _warning("Direcory already exists *behind the symlink* on filesystem. This may break upgrade/remove if you change that symlink in the future. (%s)", sane_path);
+        _warning("Directory already exists *behind the symlink* on filesystem. This may break upgrade/remove if you change that symlink in the future. (%s)", sane_path);
       }
       else if (ex_type == SYS_NONE)
       {

--- a/src/cmd-install.c
+++ b/src/cmd-install.c
@@ -244,13 +244,6 @@ static void _extract_file(struct untgz_state* tgz, struct db_pkg* pkg,
 
   /* EXIT: free(fullpath), free(temppath) */
 
-  /* add file to the package */
-  if (db_pkg_add_path(pkg, sane_path, tgz->f_type == UNTGZ_DIR ? DB_PATH_DIR : DB_PATH_FILE))
-  {
-    e_set(E_ERROR, "Can't add path to the package, it's too long. (%s)", sane_path);
-    goto extract_failed;
-  }
-
   /* Here we must check interaction of following conditions:
    *
    * - type of the file we are installing (tgz->f_type)
@@ -642,6 +635,13 @@ gint cmd_install(const gchar* pkgfile, const struct cmd_options* opts, struct er
     /* check if package contains .desktop files */
     if (!need_update_icon_cache && g_str_has_suffix(sane_path, ".desktop"))
       need_update_icon_cache = 1;
+
+    /* add file to the package */
+    if (db_pkg_add_path(pkg, sane_path, tgz->f_type == UNTGZ_DIR ? DB_PATH_DIR : DB_PATH_FILE))
+    {
+      e_set(E_ERROR, "Can't add path to the package, it's too long. (%s)", sane_path);
+      goto err3;
+    }
 
     /* check for metadata files */
     if (!strcmp(sane_path, "install/slack-desc"))

--- a/src/cmd-list.c
+++ b/src/cmd-list.c
@@ -73,8 +73,6 @@ gint cmd_list(GSList* arglist, const struct cmd_options* opts, struct error* e)
     if (verbose)
     {
       struct db_pkg* pkg = i->data;
-      gfloat csizef = (float) pkg->csize/1024;
-      gfloat usizef = (float) pkg->usize/1024;
       printf("+===================================================================+\n");
       printf("| %-65s |\n", pkg->name);
       printf("+===================================================================+\n");
@@ -83,24 +81,8 @@ gint cmd_list(GSList* arglist, const struct cmd_options* opts, struct error* e)
       printf("ARCH:    %s\n", pkg->arch);
       printf("BUILD:   %s\n", pkg->build);
       printf("DATE:    %s\n", _get_date(pkg->time));
-      // Print compressed size with no decimals in KB, when size < 1MB
-      // with one decimal in MB, when size < 10MB
-      // and with no decimals in MB when size >= 10MB 
-      if (pkg->csize < 1024)
-	      printf("CSIZE:   %u KB\n", pkg->csize);
-      else if (csizef < 10)
-	      printf("CSIZE:   %2.1f MB\n", csizef);
-      else
-	      printf("CSIZE:   %.0f MB\n", csizef);
-      // Print uncompressed size with no decimals in KB, when size < 1MB
-      // with one decimal in MB, when size < 10MB
-      // and with no decimals in MB when size >= 10MB 
-      if (pkg->usize < 1024)
-	      printf("USIZE:   %u KB\n", pkg->usize);
-      else if (usizef < 10)
-	      printf("USIZE:   %2.1f MB\n", usizef);
-      else
-	      printf("USIZE:   %.0f MB\n", usizef);
+      printf("CSIZE:   %u kB\n", pkg->csize);
+      printf("USIZE:   %u kB\n", pkg->usize);
       if (pkg->desc)
         printf("%s", pkg->desc);
     }

--- a/src/cmd-list.c
+++ b/src/cmd-list.c
@@ -73,6 +73,8 @@ gint cmd_list(GSList* arglist, const struct cmd_options* opts, struct error* e)
     if (verbose)
     {
       struct db_pkg* pkg = i->data;
+      gfloat csizef = (float) pkg->csize/1024;
+      gfloat usizef = (float) pkg->usize/1024;
       printf("+===================================================================+\n");
       printf("| %-65s |\n", pkg->name);
       printf("+===================================================================+\n");
@@ -81,8 +83,24 @@ gint cmd_list(GSList* arglist, const struct cmd_options* opts, struct error* e)
       printf("ARCH:    %s\n", pkg->arch);
       printf("BUILD:   %s\n", pkg->build);
       printf("DATE:    %s\n", _get_date(pkg->time));
-      printf("CSIZE:   %u kB\n", pkg->csize);
-      printf("USIZE:   %u kB\n", pkg->usize);
+      // Print compressed size with no decimals in KB, when size < 1MB
+      // with one decimal in MB, when size < 10MB
+      // and with no decimals in MB when size >= 10MB 
+      if (pkg->csize < 1024)
+	      printf("CSIZE:   %u KB\n", pkg->csize);
+      else if (csizef < 10)
+	      printf("CSIZE:   %2.1f MB\n", csizef);
+      else
+	      printf("CSIZE:   %.0f MB\n", csizef);
+      // Print uncompressed size with no decimals in KB, when size < 1MB
+      // with one decimal in MB, when size < 10MB
+      // and with no decimals in MB when size >= 10MB 
+      if (pkg->usize < 1024)
+	      printf("USIZE:   %u KB\n", pkg->usize);
+      else if (usizef < 10)
+	      printf("USIZE:   %2.1f MB\n", usizef);
+      else
+	      printf("USIZE:   %.0f MB\n", usizef);
       if (pkg->desc)
         printf("%s", pkg->desc);
     }

--- a/src/cmd-upgrade.c
+++ b/src/cmd-upgrade.c
@@ -789,6 +789,7 @@ gint cmd_upgrade(const gchar* pkgfile, const struct cmd_options* opts, struct er
         goto err3;
       }
       _read_slackdesc(tgz, pkg);
+      db_pkg_add_path(pkg, "install/slack-desc", DB_PATH_FILE);
       continue;
     }
     else if (!strcmp(sane_path, "install/doinst.sh"))
@@ -804,6 +805,7 @@ gint cmd_upgrade(const gchar* pkgfile, const struct cmd_options* opts, struct er
         e_set(E_ERROR, "Installation script processing failed.");
         goto err3;
       }
+      db_pkg_add_path(pkg, "install/doinst.sh", DB_PATH_FILE);
       continue;
     }
     else if (!strncmp(sane_path, "install/", 8) && strcmp(sane_path, "install"))

--- a/src/cmd-upgrade.c
+++ b/src/cmd-upgrade.c
@@ -470,7 +470,7 @@ static void _extract_file(struct untgz_state* tgz, struct db_pkg* pkg,
         }
         else if (tmp_type == SYS_DIR)
         {
-          e_set(E_ERROR, "Temporary file path is used by a direcotry. (%s)", temppath);
+          e_set(E_ERROR, "Temporary file path is used by a directory. (%s)", temppath);
           goto extract_failed;
         }
         else if (tmp_type != SYS_NONE)

--- a/src/cmd-upgrade.c
+++ b/src/cmd-upgrade.c
@@ -314,12 +314,12 @@ static void _extract_file(struct untgz_state* tgz, struct db_pkg* pkg,
         }
         else
         {
-          _debug("Direcory already exists %s", sane_path);
+          _debug("Directory already exists %s", sane_path);
         }
       }
       else if (ex_type == SYS_SYM && ex_deref_type == SYS_DIR)
       {
-        _warning("Direcory already exists *behind the symlink* on filesystem. This may break upgrade/remove if you change that symlink in the future. (%s)", sane_path);
+        _warning("Directory already exists *behind the symlink* on filesystem. This may break upgrade/remove if you change that symlink in the future. (%s)", sane_path);
       }
       else if (ex_type == SYS_NONE)
       {

--- a/src/cmd-upgrade.c
+++ b/src/cmd-upgrade.c
@@ -250,13 +250,6 @@ static void _extract_file(struct untgz_state* tgz, struct db_pkg* pkg,
 
   /* EXIT: free(fullpath), free(temppath) */
 
-  /* add file to the package */
-  if (db_pkg_add_path(pkg, sane_path, tgz->f_type == UNTGZ_DIR ? DB_PATH_DIR : DB_PATH_FILE))
-  {
-    e_set(E_ERROR, "Can't add path to the package, it's too long. (%s)", sane_path);
-    goto extract_failed;
-  }
-
   /* Here we must check interaction of following conditions:
    *
    * - type of the file we are installing (tgz->f_type)
@@ -779,6 +772,13 @@ gint cmd_upgrade(const gchar* pkgfile, const struct cmd_options* opts, struct er
     /* check if package contains .desktop files */
     if (!need_update_icon_cache && g_str_has_suffix(sane_path, ".desktop"))
       need_update_icon_cache = 1;
+
+    /* add file to the package */
+    if (db_pkg_add_path(pkg, sane_path, tgz->f_type == UNTGZ_DIR ? DB_PATH_DIR : DB_PATH_FILE))
+    {
+      e_set(E_ERROR, "Can't add path to the package, it's too long. (%s)", sane_path);
+      goto err3;
+    }
 
     /* check for metadata files */
     if (!strcmp(sane_path, "install/slack-desc"))

--- a/src/pkgdb.c
+++ b/src/pkgdb.c
@@ -769,20 +769,34 @@ struct db_pkg* db_get_pkg(gchar* name, db_get_type type)
     else if (!m[1] && LINEMATCH("COMPRESSED PACKAGE SIZE:"))
     {
       gchar* size = line + LINESIZE("COMPRESSED PACKAGE SIZE:");
-      if (sscanf(size, " %u ", &p->csize) != 1)
+      gchar suffix = NULL;
+      if (sscanf(size, " %u %c", &p->csize, &suffix) != 2)
       {
         e_set(E_ERROR, "Can't parse compressed package size. (%s)", size);
         goto err_1;
+      }
+      /* always report size in KB, even when it's in MB in the package
+       * database */
+      if (suffix == 'M')
+      {
+        p->csize = p->csize*1024;
       }
       m[1] = 1;
     }
     else if (!m[2] && LINEMATCH("UNCOMPRESSED PACKAGE SIZE:"))
     {
       gchar* size = line + LINESIZE("UNCOMPRESSED PACKAGE SIZE:");
-      if (sscanf(size, " %u ", &p->usize) != 1)
+      gchar suffix = NULL;
+      if (sscanf(size, " %u %c", &p->usize, &suffix) != 2)
       {
         e_set(E_ERROR, "Can't parse uncompressed package size. (%s)", size);
         goto err_1;
+      }
+      /* always report size in KB, even when it's in MB in the package
+       * database */
+      if (suffix == 'M')
+      {
+        p->usize = p->usize*1024;
       }
       m[2] = 1;
     }

--- a/src/pkgdb.c
+++ b/src/pkgdb.c
@@ -769,8 +769,9 @@ struct db_pkg* db_get_pkg(gchar* name, db_get_type type)
     else if (!m[1] && LINEMATCH("COMPRESSED PACKAGE SIZE:"))
     {
       gchar* size = line + LINESIZE("COMPRESSED PACKAGE SIZE:");
+      gfloat csizef = 0;
       gchar suffix = NULL;
-      if (sscanf(size, " %u %c", &p->csize, &suffix) != 2)
+      if (sscanf(size, " %f %c", &csizef, &suffix) != 2)
       {
         e_set(E_ERROR, "Can't parse compressed package size. (%s)", size);
         goto err_1;
@@ -779,15 +780,17 @@ struct db_pkg* db_get_pkg(gchar* name, db_get_type type)
        * database */
       if (suffix == 'M')
       {
-        p->csize = p->csize*1024;
+        csizef = csizef*1024;
       }
+      p->csize = (int) csizef;
       m[1] = 1;
     }
     else if (!m[2] && LINEMATCH("UNCOMPRESSED PACKAGE SIZE:"))
     {
       gchar* size = line + LINESIZE("UNCOMPRESSED PACKAGE SIZE:");
+      gfloat usizef = 0;
       gchar suffix = NULL;
-      if (sscanf(size, " %u %c", &p->usize, &suffix) != 2)
+      if (sscanf(size, " %f %c", &usizef, &suffix) != 2)
       {
         e_set(E_ERROR, "Can't parse uncompressed package size. (%s)", size);
         goto err_1;
@@ -796,8 +799,9 @@ struct db_pkg* db_get_pkg(gchar* name, db_get_type type)
        * database */
       if (suffix == 'M')
       {
-        p->usize = p->usize*1024;
+        usizef = usizef*1024;
       }
+      p->usize = (int) usizef;
       m[2] = 1;
     }
     else if (!m[3] && LINEMATCH("PACKAGE LOCATION:"))

--- a/src/pkgdb.c
+++ b/src/pkgdb.c
@@ -484,83 +484,15 @@ static gint _db_add_pkg(struct db_pkg* pkg, gchar* origname)
 #endif
 
   /* construct header */
-  gfloat csizef = (float) pkg->csize/1024;
-  gfloat usizef = (float) pkg->usize/1024;
-  /* header package name */
   if (fprintf(pf,
-    "PACKAGE NAME:     %s\n",
-    pkg->name) <0)
-   {
-     goto err_2;
-   }
-  /* header compressed package size
-   * print in KB with not decimals when size < 1024KB
-   * in MB with one decimal when size < 10 MB
-   * in MB with no decimals when size >= 10 MB */
-  if (pkg->csize < 1024)
-  {
-    if(fprintf(pf,
-    "COMPRESSED PACKAGE SIZE:     %uK\n",
-    pkg->csize) <0)
-    {
-      goto err_2;
-    }
-  }
-  else if (csizef < 10)
-  {
-    if(fprintf(pf,
-    "COMPRESSED PACKAGE SIZE:     %2.1fM\n",
-    csizef) <0)
-    {
-      goto err_2;
-    }
-  }
-  else
-  {
-    if(fprintf(pf,
-    "COMPRESSED PACKAGE SIZE:     %.0fM\n",
-    csizef) <0)
-    {
-      goto err_2;
-    }
-  }
-  /* header uncompressed package size
-   * print in KB with not decimals when size < 1024KB
-   * in MB with one decimal when size < 10 MB
-   * in MB with no decimals when size >= 10 MB */
-  if (pkg->usize < 1024)
-  {
-    if(fprintf(pf,
-    "UNCOMPRESSED PACKAGE SIZE:     %uK\n",
-    pkg->usize) <0)
-    {
-      goto err_2;
-    }
-  }
-  else if (usizef < 10)
-  {
-    if(fprintf(pf,
-    "UNCOMPRESSED PACKAGE SIZE:     %2.1fM\n",
-    usizef) <0)
-    {
-      goto err_2;
-    }
-  }
-  else
-  {
-    if(fprintf(pf,
-    "UNCOMPRESSED PACKAGE SIZE:     %.0fM\n",
-    usizef) <0)
-    {
-      goto err_2;
-    }
-  }
-  /* header location and description */
-   if (fprintf(pf,
-    "PACKAGE LOCATION: %s\n"
+    "PACKAGE NAME:              %s\n"
+    "COMPRESSED PACKAGE SIZE:   %u K\n"
+    "UNCOMPRESSED PACKAGE SIZE: %u K\n"
+    "PACKAGE LOCATION:          %s\n"
     "PACKAGE DESCRIPTION:\n"
     "%s"
     "FILE LIST:\n",
+    pkg->name, pkg->csize, pkg->usize,
     pkg->location ? pkg->location : "",
     pkg->desc ? pkg->desc : "") < 0)
   {
@@ -769,39 +701,21 @@ struct db_pkg* db_get_pkg(gchar* name, db_get_type type)
     else if (!m[1] && LINEMATCH("COMPRESSED PACKAGE SIZE:"))
     {
       gchar* size = line + LINESIZE("COMPRESSED PACKAGE SIZE:");
-      gfloat csizef = 0;
-      gchar suffix = NULL;
-      if (sscanf(size, " %f %c", &csizef, &suffix) != 2)
+      if (sscanf(size, " %u ", &p->csize) != 1)
       {
         e_set(E_ERROR, "Can't parse compressed package size. (%s)", size);
         goto err_1;
       }
-      /* always report size in KB, even when it's in MB in the package
-       * database */
-      if (suffix == 'M')
-      {
-        csizef = csizef*1024;
-      }
-      p->csize = (int) csizef;
       m[1] = 1;
     }
     else if (!m[2] && LINEMATCH("UNCOMPRESSED PACKAGE SIZE:"))
     {
       gchar* size = line + LINESIZE("UNCOMPRESSED PACKAGE SIZE:");
-      gfloat usizef = 0;
-      gchar suffix = NULL;
-      if (sscanf(size, " %f %c", &usizef, &suffix) != 2)
+      if (sscanf(size, " %u ", &p->usize) != 1)
       {
         e_set(E_ERROR, "Can't parse uncompressed package size. (%s)", size);
         goto err_1;
       }
-      /* always report size in KB, even when it's in MB in the package
-       * database */
-      if (suffix == 'M')
-      {
-        usizef = usizef*1024;
-      }
-      p->usize = (int) usizef;
       m[2] = 1;
     }
     else if (!m[3] && LINEMATCH("PACKAGE LOCATION:"))

--- a/src/pkgdb.c
+++ b/src/pkgdb.c
@@ -485,10 +485,10 @@ static gint _db_add_pkg(struct db_pkg* pkg, gchar* origname)
 
   /* construct header */
   if (fprintf(pf,
-    "PACKAGE NAME:              %s\n"
-    "COMPRESSED PACKAGE SIZE:   %u K\n"
-    "UNCOMPRESSED PACKAGE SIZE: %u K\n"
-    "PACKAGE LOCATION:          %s\n"
+    "PACKAGE NAME:     %s\n"
+    "COMPRESSED PACKAGE SIZE:     %uK\n"
+    "UNCOMPRESSED PACKAGE SIZE:     %uK\n"
+    "PACKAGE LOCATION: %s\n"
     "PACKAGE DESCRIPTION:\n"
     "%s"
     "FILE LIST:\n",

--- a/src/pkgdb.c
+++ b/src/pkgdb.c
@@ -484,15 +484,83 @@ static gint _db_add_pkg(struct db_pkg* pkg, gchar* origname)
 #endif
 
   /* construct header */
+  gfloat csizef = (float) pkg->csize/1024;
+  gfloat usizef = (float) pkg->usize/1024;
+  /* header package name */
   if (fprintf(pf,
-    "PACKAGE NAME:     %s\n"
-    "COMPRESSED PACKAGE SIZE:     %uK\n"
-    "UNCOMPRESSED PACKAGE SIZE:     %uK\n"
+    "PACKAGE NAME:     %s\n",
+    pkg->name) <0)
+   {
+     goto err_2;
+   }
+  /* header compressed package size
+   * print in KB with not decimals when size < 1024KB
+   * in MB with one decimal when size < 10 MB
+   * in MB with no decimals when size >= 10 MB */
+  if (pkg->csize < 1024)
+  {
+    if(fprintf(pf,
+    "COMPRESSED PACKAGE SIZE:     %uK\n",
+    pkg->csize) <0)
+    {
+      goto err_2;
+    }
+  }
+  else if (csizef < 10)
+  {
+    if(fprintf(pf,
+    "COMPRESSED PACKAGE SIZE:     %2.1fM\n",
+    csizef) <0)
+    {
+      goto err_2;
+    }
+  }
+  else
+  {
+    if(fprintf(pf,
+    "COMPRESSED PACKAGE SIZE:     %.0fM\n",
+    csizef) <0)
+    {
+      goto err_2;
+    }
+  }
+  /* header uncompressed package size
+   * print in KB with not decimals when size < 1024KB
+   * in MB with one decimal when size < 10 MB
+   * in MB with no decimals when size >= 10 MB */
+  if (pkg->usize < 1024)
+  {
+    if(fprintf(pf,
+    "UNCOMPRESSED PACKAGE SIZE:     %uK\n",
+    pkg->usize) <0)
+    {
+      goto err_2;
+    }
+  }
+  else if (usizef < 10)
+  {
+    if(fprintf(pf,
+    "UNCOMPRESSED PACKAGE SIZE:     %2.1fM\n",
+    usizef) <0)
+    {
+      goto err_2;
+    }
+  }
+  else
+  {
+    if(fprintf(pf,
+    "UNCOMPRESSED PACKAGE SIZE:     %.0fM\n",
+    usizef) <0)
+    {
+      goto err_2;
+    }
+  }
+  /* header location and description */
+   if (fprintf(pf,
     "PACKAGE LOCATION: %s\n"
     "PACKAGE DESCRIPTION:\n"
     "%s"
     "FILE LIST:\n",
-    pkg->name, pkg->csize, pkg->usize,
     pkg->location ? pkg->location : "",
     pkg->desc ? pkg->desc : "") < 0)
   {

--- a/src/taction.c
+++ b/src/taction.c
@@ -286,7 +286,7 @@ gint ta_finalize()
       {
         if (chmod(a->path1, a->mode) == -1)
         {
-          _warning("Failed to cange mode on %s to %04o (%s)", a->path1, a->mode, strerror(errno));
+          _warning("Failed to change mode on %s to %04o (%s)", a->path1, a->mode, strerror(errno));
         }
       }
       /* chown */
@@ -296,7 +296,7 @@ gint ta_finalize()
 #ifndef __WIN32__  
         if (chown(a->path1, a->owner, a->group) == -1)
         {
-          _warning("Failed to cange owner on %s to %d:%d (%s)", a->path1, a->owner, a->group, strerror(errno));
+          _warning("Failed to change owner on %s to %d:%d (%s)", a->path1, a->owner, a->group, strerror(errno));
         }
 #endif		  
       }


### PR DESCRIPTION
Hi Ondřej,

I took the liberty of making some changes to spkg. The most important ones are about the way formats the package information in the package database. I've had some complaints that it doesn't exactly match the way pkgtools formats the same information and that scripts that may be parsing that information expecting the exact same formatting of pkgtools may fail for packages installed with spkg. spkg reported all sizes only in KB, but pkgtools report sizes in KB if the package size is <1MB, in MBs with one decimal point if the package size is <10MB and in MBs with no decimal points if the package size is >10MB. There are also some whitespace changes; I did like the way whitespace was printed with spkg better, but I've made the changes so it matches the way pkgtools print whitespace.

Another change is that spkg would not include the slack-desc and doinst.sh files in the package logs, while pkgtools do. I've added them too, people may use a grep in /var/log/packages to check which packages have a doinst.sh script for example.

I have also added an entry for the --no-gtk-update-icon-cache option in the manpage, I forgot to include that in the patch that I had send you before.

And then there are some minor typos that I fixed. Feel free to inspect my changes and pull them if you like them.

Regards,

George
